### PR TITLE
Update to WorldGuard 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <majorversion>0.1</majorversion>
         <state>indev</state>
-        <bukkit.version>1.7.2-R0.3</bukkit.version>
-        <worldguard.version>5.9.1-SNAPSHOT</worldguard.version>
+        <bukkit.version>1.8-R0.1-SNAPSHOT</bukkit.version>
+        <worldguard.version>6.0.0-SNAPSHOT</worldguard.version>
         <vault.version>1.2.32</vault.version>
     </properties>
 

--- a/src/main/java/com/thezorro266/bukkit/srm/WorldGuardManager.java
+++ b/src/main/java/com/thezorro266/bukkit/srm/WorldGuardManager.java
@@ -20,6 +20,7 @@ package com.thezorro266.bukkit.srm;
 
 import java.lang.ref.WeakReference;
 import java.util.Set;
+import java.util.UUID;
 import java.util.WeakHashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -32,7 +33,8 @@ import com.sk89q.worldedit.Vector;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.domains.DefaultDomain;
-import com.sk89q.worldguard.protection.databases.ProtectionDatabaseException;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.thezorro266.bukkit.srm.factories.RegionFactory;
 
@@ -174,7 +176,7 @@ public class WorldGuardManager {
 			return list;
 		}
 
-		public void saveChanges() throws ProtectionDatabaseException {
+		public void saveChanges() throws StorageException {
 			worldguardPlugin.getRegionManager(world).save();
 		}
 	}
@@ -258,6 +260,11 @@ public class WorldGuardManager {
 						.warning(LanguageSupport.instance.getString("worldguard.offlineplayer.getpermission"));
 				return true;
 			}
+		}
+
+		@Override
+		public UUID getUniqueId() {
+			return player.getUniqueId();
 		}
 
 	}

--- a/src/main/java/com/thezorro266/bukkit/srm/templates/OwnableRegionTemplate.java
+++ b/src/main/java/com/thezorro266/bukkit/srm/templates/OwnableRegionTemplate.java
@@ -20,7 +20,8 @@ package com.thezorro266.bukkit.srm.templates;
 
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
-import com.sk89q.worldguard.protection.databases.ProtectionDatabaseException;
+
+import com.sk89q.worldguard.protection.managers.storage.StorageException;
 import com.thezorro266.bukkit.srm.SimpleRegionMarket;
 import com.thezorro266.bukkit.srm.WorldGuardManager;
 import com.thezorro266.bukkit.srm.factories.RegionFactory;
@@ -68,7 +69,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -86,7 +87,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -101,7 +102,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -116,7 +117,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -131,7 +132,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -146,7 +147,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}
@@ -167,7 +168,7 @@ public abstract class OwnableRegionTemplate extends SignTemplate implements Owna
 		try {
 			wgo.saveChanges();
 			return true;
-		} catch (ProtectionDatabaseException e) {
+		} catch (StorageException e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
I've just updated SRM as part of trying to get our server running on spigot 1.8.

I don't think this change is backwards compatible with WG 5 so I'm not sure if you would want to create another class to allow dynamic detection.

One other important thing to note is that you need to install bukkit 1.8 by hand (I created a lib directory and placed it in there), maybe other maven repos have it but I've not checked.
